### PR TITLE
Corrections for php 8.0

### DIFF
--- a/Classes/Controller/QuizController.php
+++ b/Classes/Controller/QuizController.php
@@ -404,7 +404,7 @@ class QuizController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 	    			$this->participant->setName($defaultName);
 	    			$this->participant->setEmail($defaultEmail);
 	    			$this->participant->setHomepage($defaultHomepage);
-	    			$this->participant->setUser(intval($GLOBALS['TSFE']->fe_user->user['uid']));
+	    			$this->participant->setUser(isset($GLOBALS['TSFE']->fe_user->user['uid']) ? intval($GLOBALS['TSFE']->fe_user->user['uid']) : 0);
 	    			$this->participant->setIp($this->getRealIpAddr());
 	    			$this->participant->setSession($session);
                     if ($startTime) {
@@ -440,7 +440,7 @@ class QuizController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     			$debug .= "\n#" . $quid . '#: ';
     			if ($this->request->hasArgument('quest_' . $quid) && $this->request->getArgument('quest_' . $quid)) {
     				$isActive = true;
-    			} else if ($_POST['quest_' . $quid] || $_GET['quest_' . $quid]) {
+    			} else if (isset($_POST['quest_' . $quid]) || isset($_GET['quest_' . $quid])) {
     				// Ajax-call is without extensionname :-(
     				$isActive = true;
     			} else {
@@ -571,7 +571,7 @@ class QuizController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 	    								}
 	    							}
 	    							$selected->addAnswer($selectedAnswer);
-	    							if ($emailAnswers[$quid][$selectedAnswerUid]) {
+	    							if (isset($emailAnswers[$quid][$selectedAnswerUid])) {
 	    								$specialRecievers[$emailAnswers[$quid][$selectedAnswerUid]['email']] = $emailAnswers[$quid][$selectedAnswerUid];
 	    							}
 	    						}

--- a/Classes/Hooks/PageLayoutView.php
+++ b/Classes/Hooks/PageLayoutView.php
@@ -165,7 +165,8 @@ class PageLayoutView
                    $this->getLanguageService()->sL(self::LLPATH . 'settings.ajax'),
                    (($ajax) ? $this->getLanguageService()->sL(self::LLPATH . 'settings.yes') : $this->getLanguageService()->sL(self::LLPATH . 'settings.no'))
                ];
-               if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXT']['fp_masterquiz']['Quizpalme\\fp_masterquiz\\Hooks\\PageLayoutView']['extensionSummary'])) {
+               if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['fp_masterquiz']['Quizpalme\\fp_masterquiz\\Hooks\\PageLayoutView']['extensionSummary'])
+                   && is_array($GLOBALS['TYPO3_CONF_VARS']['EXT']['fp_masterquiz']['Quizpalme\\fp_masterquiz\\Hooks\\PageLayoutView']['extensionSummary'])) {
                     $params = [
                         'action' => $actionTranslationKey
                     ];
@@ -302,8 +303,8 @@ class PageLayoutView
         $flexform = $this->flexformData;
         if (isset($flexform['data'])) {
             $flexform = $flexform['data'];
-            if (is_array($flexform) && is_array($flexform[$sheet]) && is_array($flexform[$sheet]['lDEF'])
-                && is_array($flexform[$sheet]['lDEF'][$key]) && isset($flexform[$sheet]['lDEF'][$key]['vDEF'])
+            if (isset($flexform) && isset($flexform[$sheet]) && isset($flexform[$sheet]['lDEF']) 
+                && isset($flexform[$sheet]['lDEF'][$key]) && isset($flexform[$sheet]['lDEF'][$key]['vDEF'])
             ) {
                 return $flexform[$sheet]['lDEF'][$key]['vDEF'];
             }


### PR DESCRIPTION
Hi Kurt,

thank you for this great plugin, which is doing a wonderful work on my homepage.
I have switched my Typo installation to V. 11.5 with php 8. 
I'm afraid some of your codings are not php 8 ready yet. I had crash dumps when I access a page in the backend with the plugin and also in the frontend.
The main reason ist, that access to non existing array key, is throwing an error now.
I have done the following changings and now my installation is working properly with your plugin.
Maybe you will include this in your branch.

Regards
Gerald