### PR TITLE
[BUGFIX] Disable LanguageOverlayMode in QuizRepository

### DIFF
--- a/Classes/Controller/QuizController.php
+++ b/Classes/Controller/QuizController.php
@@ -1395,7 +1395,7 @@ class QuizController extends ActionController
      */
     public function showAction(\Fixpunkt\FpMasterquiz\Domain\Model\Quiz $quiz)
     {
-        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getUid())) {
+        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getLocalizedUid())) {
             return;
         }
         if ($this->checkForClosure()) {
@@ -1465,7 +1465,7 @@ class QuizController extends ActionController
      */
     public function showByTagAction(\Fixpunkt\FpMasterquiz\Domain\Model\Quiz $quiz)
     {
-        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getUid())) {
+        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getLocalizedUid())) {
             return;
         }
         if ($this->checkForClosure()) {
@@ -1565,7 +1565,7 @@ class QuizController extends ActionController
      */
     public function showAjaxAction(\Fixpunkt\FpMasterquiz\Domain\Model\Quiz $quiz)
     {
-        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getUid())) {
+        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getLocalizedUid())) {
             return;
         }
         if ($this->checkForClosure()) {
@@ -1680,7 +1680,7 @@ class QuizController extends ActionController
      */
     public function resultAction(\Fixpunkt\FpMasterquiz\Domain\Model\Quiz $quiz)
     {
-        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getUid())) {
+        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getLocalizedUid())) {
             return;
         }
         $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
@@ -1702,7 +1702,7 @@ class QuizController extends ActionController
      */
     public function highscoreAction(\Fixpunkt\FpMasterquiz\Domain\Model\Quiz $quiz)
     {
-        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getUid())) {
+        if (!$this->checkQuizAccess($quiz->getPid(), $quiz->getLocalizedUid())) {
             return;
         }
         $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');

--- a/Classes/Domain/Model/Quiz.php
+++ b/Classes/Domain/Model/Quiz.php
@@ -403,4 +403,11 @@ class Quiz extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         }
         return $maximum2;
     }
+
+    /**
+     * @return int
+     */
+    public function getLocalizedUid() {
+        return $this->_localizedUid;
+    }
 }

--- a/Classes/Domain/Repository/QuizRepository.php
+++ b/Classes/Domain/Repository/QuizRepository.php
@@ -28,6 +28,22 @@ class QuizRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
         'sorting' => QueryInterface::ORDER_ASCENDING
     ];
 
+    
+    /**
+     * Sets the initial query settings
+     * @return void
+     */
+    public function initializeObject()
+    {
+        /** @var QuerySettingsInterface $querySettings */
+        $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
+
+        $querySettings->setRespectStoragePage(false);
+        $querySettings->setLanguageOverlayMode(false);
+
+        $this->setDefaultQuerySettings($querySettings);
+    }
+
 
     /**
      * Fetches entries of a folder.

--- a/Classes/Domain/Repository/QuizRepository.php
+++ b/Classes/Domain/Repository/QuizRepository.php
@@ -2,6 +2,9 @@
 
 namespace Fixpunkt\FpMasterquiz\Domain\Repository;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
+use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 


### PR DESCRIPTION
Disabling LanguageOverlayMode because it sets uid from translated Quizes to the uid of the parent (default language). This throws an error in the method checkQuizAccess in the QuizController class after the showAction was called.

I don't know if this is the best fix but we'll need this piece of code to make it run in other languages